### PR TITLE
fix: use generic float type

### DIFF
--- a/src/kernels/euclidean/forward.rs
+++ b/src/kernels/euclidean/forward.rs
@@ -24,7 +24,7 @@ pub fn forward<R: CubeRuntime, F: FloatElement, I: IntElement, BT: BoolElement>(
         device.clone(),
         output_shape,
         buffer,
-        burn::tensor::DType::F64,
+        F::dtype(),
     );
 
     // Launch the Euclidean pairwise distance kernel
@@ -69,7 +69,7 @@ pub fn backward<R: CubeRuntime, F: FloatElement, I: IntElement, BT: BoolElement>
         output.device.clone(),
         grad_output_shape,
         buffer,
-        burn::tensor::DType::F64,
+        F::dtype(),
     );
 
     // Launch the Euclidean pairwise distance kernel

--- a/src/kernels/euclidean/kernel.rs
+++ b/src/kernels/euclidean/kernel.rs
@@ -109,7 +109,7 @@ pub fn euclidean_pairwise_distance_backward_kernel<F: Float>(
     let dist = output[row * n + col];
 
     // Handle small distances (to avoid division by zero)
-    let epsilon = F::cast_from(1e-8); // Define a small epsilon value
+    let epsilon = F::new(1e-8); // Define a small epsilon value
     let dist = F::max(dist, epsilon); // Ensure dist is never less than epsilon
 
     // Skip if the distance is 0 (identical vectors)

--- a/src/kernels/knn/forward.rs
+++ b/src/kernels/knn/forward.rs
@@ -36,7 +36,7 @@ pub fn forward<R: CubeRuntime, F: FloatElement, I: IntElement, BT: BoolElement>(
         device.clone(),
         distances_shape,
         distances_buffer,
-        burn::tensor::DType::F64,
+        F::dtype(),
     );
 
     let local_shape = Shape::from(vec![k as usize]); // Local shape for k neighbors
@@ -51,7 +51,7 @@ pub fn forward<R: CubeRuntime, F: FloatElement, I: IntElement, BT: BoolElement>(
         pairwise_distances.device.clone(),
         pairwise_distances.shape.clone(),
         local_buffer.clone(),
-        burn::tensor::DType::F64,
+        F::dtype(),
     );
 
     let local_indices: CubeTensor<R> = CubeTensor::new_contiguous(
@@ -106,7 +106,7 @@ pub fn backward<R: CubeRuntime, F: FloatElement, I: IntElement, BT: BoolElement>
         pairwise_distances.device.clone(),
         pairwise_distances.shape.clone(),
         buffer,
-        burn::tensor::DType::F64,
+        F::dtype(),
     );
 
     let local_shape = Shape::from(vec![k as usize]); // Local shape for k neighbors
@@ -121,7 +121,7 @@ pub fn backward<R: CubeRuntime, F: FloatElement, I: IntElement, BT: BoolElement>
         pairwise_distances.device.clone(),
         pairwise_distances.shape.clone(),
         local_buffer.clone(),
-        burn::tensor::DType::F64,
+        F::dtype(),
     );
 
     let local_indices: CubeTensor<R> = CubeTensor::new_contiguous(
@@ -129,7 +129,7 @@ pub fn backward<R: CubeRuntime, F: FloatElement, I: IntElement, BT: BoolElement>
         pairwise_distances.device.clone(),
         pairwise_distances.shape.clone(),
         local_buffer,
-        burn::tensor::DType::F64,
+        F::dtype(),
     );
 
     // Calculate the number of blocks needed for the kernel launch


### PR DESCRIPTION
Using fast-umap as it is on main results in a `Data type mismatch (lhs: F32, rhs: F64)` error. Using the generic float type resolves this issue. However, there still seems to be a fundamental bug. The mnist example doesn't work with 

```
thread 'main' panicked at /Users/josiahparry/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/burn-tensor-0.18.0/src/tensor/data.rs:91:9:
assertion `left == right` failed: Shape [1000, 784] is invalid for input of size 7840000
  left: 784000
 right: 7840000
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I cannot seem to figure out _where_ this bug is coming from though.